### PR TITLE
fix a Qt 5.15.2 deprecation warning

### DIFF
--- a/src/fmfontcompareview.cpp
+++ b/src/fmfontcompareview.cpp
@@ -414,7 +414,7 @@ QColor FMFontCompareView::getColor(int level)
 
 void FMFontCompareView::mousePressEvent(QMouseEvent * e)
 {
-	if ( e->button() == Qt::MidButton )
+	if ( e->button() == Qt::MiddleButton )
 	{
 		mouseStartPoint =  e->pos() ;
 		isPanning = true;

--- a/src/fmplayground.cpp
+++ b/src/fmplayground.cpp
@@ -73,7 +73,7 @@ void FMPlayGround::mousePressEvent ( QMouseEvent * e )
 {
 	closeLine();
 	mouseStartPoint =  e->pos() ;
-	if ( e->button() == Qt::MidButton )
+	if ( e->button() == Qt::MiddleButton )
 	{
 		isPanning = true;
 		return;

--- a/src/fmsampletextview.cpp
+++ b/src/fmsampletextview.cpp
@@ -81,7 +81,7 @@ void FMSampleTextView::mousePressEvent ( QMouseEvent * e )
 	if ( locker )
 		return;
 
-	if ( e->button() == Qt::MidButton )
+	if ( e->button() == Qt::MiddleButton )
 	{
 		mouseStartPoint =  e->pos() ;
 		isPanning = true;

--- a/src/iview.cpp
+++ b/src/iview.cpp
@@ -124,7 +124,7 @@ void IView::mousePressEvent ( QMouseEvent * e )
 	if ( !scene() )
 		return;
 
-	if ( e->button() == Qt::MidButton )
+	if ( e->button() == Qt::MiddleButton )
 	{
 		mouseStartPoint =  e->pos() ;
 		isPanning = true;


### PR DESCRIPTION
this change fixes a QT deprecation warning that is given when building fontmatrix against Qt 5.15.2
Qt::MidButton has been replaced by Qt::MiddleButton